### PR TITLE
Fix Worker API path mappings

### DIFF
--- a/api/src/main/java/com/spring/basics/api/WorkerApi.java
+++ b/api/src/main/java/com/spring/basics/api/WorkerApi.java
@@ -24,11 +24,11 @@ public interface WorkerApi {
     @ResponseStatus(value = HttpStatus.OK)
     WorkerResponse findWorkerByCpf(@PathVariable String cpf);
 
-    @PutMapping(value = "{id}")
+    @PutMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.OK)
     Worker updateWorker(@RequestBody UpdateWorkerRequest workerRequest, @PathVariable Long id);
 
-    @DeleteMapping(value = "{id}")
+    @DeleteMapping(value = "/{id}")
     @ResponseStatus(value = HttpStatus.NO_CONTENT)
     void deleteWorker(@PathVariable Long id);
 


### PR DESCRIPTION
## Summary
- fix missing leading slashes in `WorkerApi`

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68559c09c5b88324a3e4488698348179