### PR TITLE
Fix worker service tests

### DIFF
--- a/service/src/test/java/com/spring/basics/WorkerServiceTest.java
+++ b/service/src/test/java/com/spring/basics/WorkerServiceTest.java
@@ -138,7 +138,7 @@ public class WorkerServiceTest {
 
         assertEquals(worker.getId(), result.getId());
         assertEquals(actuationArea.getId(), result.getActuationAreas().get(0).getId());
-        assertEquals(avaliation.getId(), result.getId());
+        assertEquals(avaliation.getId(), result.getAvaliations().get(0).getId());
     }
 
     @Test(expected = WorkerNotFoundException.class)
@@ -176,7 +176,7 @@ public class WorkerServiceTest {
 
         assertEquals(worker.getId(), result.getId());
         assertEquals(actuationArea.getId(), result.getActuationAreas().get(0).getId());
-        assertEquals(avaliation.getId(), result.getId());
+        assertEquals(avaliation.getId(), result.getAvaliations().get(0).getId());
     }
 
     @Test(expected = WorkerNotFoundException.class)
@@ -185,7 +185,7 @@ public class WorkerServiceTest {
         Worker worker = new Worker();
         worker.setCpf("12312312312");
 
-        workerService.findWorkerById(1L);
+        workerService.findWorkerByCpf(worker.getCpf());
 
     }
 }


### PR DESCRIPTION
## Summary
- fix assertions when finding a worker by ID or CPF
- check for non-existent worker using `findWorkerByCpf`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68559d4ff0a08324a448a4cc9ffc36a1